### PR TITLE
Fix CLI error handling

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -4,5 +4,5 @@ const semmit = require('../lib/semmit.js');
 (async () => {
     await semmit
         .start()
-        .catch((error) => console.error);
+        .catch((error) => console.error(error));
 })();


### PR DESCRIPTION
## Summary
- ensure CLI shows errors when semmit fails

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848a6d0f5108332a7924239487e9d51